### PR TITLE
Fix windows file encoding issue

### DIFF
--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -24,7 +24,7 @@ class KPipeline:
         if config_path is None:
             config_path = hf_hub_download(repo_id=REPO_ID, filename='config.json')
         assert os.path.exists(config_path)
-        with open(config_path, 'r') as r:
+        with open(config_path, 'r', encoding='utf8') as r:
             config = json.load(r)
         if model_path is None:
             model_path = hf_hub_download(repo_id=REPO_ID, filename='kokoro-v1_0.pth')


### PR DESCRIPTION
basically windows defaults to win1252(cp1252) here whereas linux/mac uses utf8 by default
by specifying utf8, this repo runs on windows