### PR TITLE
Word level timestamps

### DIFF
--- a/kokoro/__init__.py
+++ b/kokoro/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.5'
+__version__ = '0.7.0'
 
 from loguru import logger
 import sys

--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -13,7 +13,7 @@ ALIASES = {
     'en-gb': 'b',
     'es': 'e',
     'fr-fr': 'f',
-    'hi': 'h'
+    'hi': 'h',
     'it': 'i',
     'pt-br': 'p',
     'ja': 'j',

--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -223,7 +223,8 @@ class KPipeline:
 
     @classmethod
     def join_timestamps(cls, tokens: List[en.MToken], pred_dur: torch.LongTensor):
-        # TODO
+        # HACK: Magic number 600 going from pred_dur frames to sample_rate of 24000
+        # print(pred_dur.shape)
         return
 
     @dataclass
@@ -280,7 +281,7 @@ class KPipeline:
                         logger.warning(f"Unexpected len(ps) == {len(ps)} > 510 and ps == '{ps}'")
                         ps = ps[:510]
                     output = KPipeline.infer(model, ps, pack, speed) if model else None
-                    if output and output.pred_dur:
+                    if output is not None and output.pred_dur is not None:
                         KPipeline.join_timestamps(tks, output.pred_dur)
                     yield self.Result(graphemes=gs, phonemes=ps, tokens=tks, output=output)
             else:

--- a/setup.py
+++ b/setup.py
@@ -2,12 +2,12 @@ from setuptools import setup, find_packages
 
 setup(
     name='kokoro',
-    version='0.3.5',
+    version='0.7.0',
     packages=find_packages(),
     install_requires=[
         'huggingface_hub',
         'loguru',
-        'misaki[en]>=0.6.7',
+        'misaki[en]>=0.7.0',
         'numpy==1.26.4',
         'scipy',
         'torch',


### PR DESCRIPTION
- Use `MToken` from https://github.com/hexgrad/misaki/pull/21
- Bump `kokoro` to version `0.7.K`, which will match `misaki` versions `0.7.M`
- Targets #32 