### PR TITLE
replace `np.prod()` with `math.prod()` to make Kokoro `torch.compile`-able

### DIFF
--- a/kokoro/istftnet.py
+++ b/kokoro/istftnet.py
@@ -277,7 +277,7 @@ class Generator(nn.Module):
                 self.resblocks.append(AdaINResBlock1(ch, k, d, style_dim))
             c_cur = upsample_initial_channel // (2 ** (i + 1))
             if i + 1 < len(upsample_rates):
-                stride_f0 = np.prod(upsample_rates[i + 1:])
+                stride_f0 = math.prod(upsample_rates[i + 1:])
                 self.noise_convs.append(nn.Conv1d(
                     gen_istft_n_fft + 2, c_cur, kernel_size=stride_f0 * 2, stride=stride_f0, padding=(stride_f0+1) // 2))
                 self.noise_res.append(AdaINResBlock1(c_cur, 7, [1,3,5], style_dim))

--- a/kokoro/istftnet.py
+++ b/kokoro/istftnet.py
@@ -1,4 +1,5 @@
 # https://github.com/yl4579/StyleTTS2/blob/main/Modules/istftnet.py
+import math
 from scipy.signal import get_window
 from torch.nn.utils import weight_norm
 import numpy as np
@@ -259,9 +260,9 @@ class Generator(nn.Module):
         self.num_upsamples = len(upsample_rates)
         self.m_source = SourceModuleHnNSF(
                     sampling_rate=24000,
-                    upsample_scale=np.prod(upsample_rates) * gen_istft_hop_size,
+                    upsample_scale=math.prod(upsample_rates) * gen_istft_hop_size,
                     harmonic_num=8, voiced_threshod=10)
-        self.f0_upsamp = nn.Upsample(scale_factor=np.prod(upsample_rates) * gen_istft_hop_size)
+        self.f0_upsamp = nn.Upsample(scale_factor=math.prod(upsample_rates) * gen_istft_hop_size)
         self.noise_convs = nn.ModuleList()
         self.noise_res = nn.ModuleList()
         self.ups = nn.ModuleList()


### PR DESCRIPTION
Using `np.prod()` will return a numpy type, which Pytorch will transform it into FakeTensor while compiling it. This will cause error with the `F.upsample()` operator.

```python
from kokoro import KPipeline

pipe = KPipeline("a")
text = "The sky above the port was the color of television, tuned to a dead channel."

pipe.model.compile()
[x for _, _, x in pipe(text, voice='af_heart')]
```
```
TypeError: upsample_linear1d() received an invalid combination of arguments - got (Tensor, NoneType, bool, list), but expected one of:
 * (Tensor input, tuple of ints output_size, bool align_corners, tuple of floats scale_factors)
      didn't match because some of the arguments have invalid types: (Tensor, !NoneType!, bool, !list of [numpy.ndarray]!)
 * (Tensor input, tuple of ints output_size, bool align_corners, float scales = None, *, Tensor out = None)
```

This PR simply replaces `np.prod()` with `math.prod()`, which has the same functionality, but returns an ordinary Python number. This makes `torch.compile()` successful, though there are still plenty of graph breaks (I will address this in subsequent PRs).

Potential of `torch.compile()`

```python
from kokoro import KPipeline
import time

pipe = KPipeline("a")
text = "The sky above the port was the color of television, tuned to a dead channel."

N = 100

audio = [x for _, _, x in pipe(text, voice='af_heart')]

t0 = time.time()
for _ in range(N):
    audio = [x for _, _, x in pipe(text, voice='af_heart')]
print(f"Eager: {(time.time() - t0) / N * 100:.2f} ms")

pipe.model.compile()
audio = [x for _, _, x in pipe(text, voice='af_heart')]

t0 = time.time()
for _ in range(N):
    audio = [x for _, _, x in pipe(text, voice='af_heart')]
print(f"Compile: {(time.time() - t0) / N * 100:.2f} ms")
```
```
# on 4070Ti SUPER
Eager: 4.20 ms
Compile: 3.13 ms
```