### PR TITLE
Add additional onnx export compatibility

### DIFF
--- a/kokoro/istftnet.py
+++ b/kokoro/istftnet.py
@@ -23,7 +23,8 @@ def get_padding(kernel_size, dilation=1):
 class AdaIN1d(nn.Module):
     def __init__(self, style_dim, num_features):
         super().__init__()
-        self.norm = nn.InstanceNorm1d(num_features, affine=False)
+        # affine should be False, however there's a bug in the old torch.onnx.export (not newer dynamo) that causes the channel dimension to be lost if affine=False. When affine is true, there's additional learnably parameters. This shouldn't really matter setting it to True, since we're in inference mode
+        self.norm = nn.InstanceNorm1d(num_features, affine=True)
         self.fc = nn.Linear(style_dim, num_features*2)
 
     def forward(self, x, s):


### PR DESCRIPTION
I was checking out the main branch, and looks like I overlooked some compatibility in my previous change https://github.com/hexgrad/kokoro/pull/87

specifically, this comment isn't true https://github.com/hexgrad/kokoro/pull/87#issuecomment-2655243558. I had some dependency oopses when testing, and it hid the issue. This seems like its just a bug in the older torch onnx export, as described here: https://github.com/pytorch/pytorch/issues/92977

Here, I just added the workaround of adding the `affine=True`, which seems like it should be harmless for inference-only. I could alternately modify the `disable_complex` to be an `onnx_compat` flag, and pass that through, but that would be a little bit of an ugly change with all of the components that it would need to be passed down to.