### PR TITLE
Added support for customized model download paths and local model loading

### DIFF
--- a/examples/download_custom_dir_example.py
+++ b/examples/download_custom_dir_example.py
@@ -6,8 +6,8 @@ from typing import Generator
 
 lang_code = 'a'
 repo_id = 'hexgrad/Kokoro-82M'
-cache_dir = os.path.expanduser('~/kokoro_models')
-local_dir = cache_dir
+cache_dir = os.path.expanduser('~/kokoro_models/cache')
+local_dir = os.path.expanduser('~/kokoro_models/local')
 voice = 'am_michael'
 
 # This text is for demonstration purposes only, unseen during training
@@ -38,12 +38,13 @@ def save_audio(generator: Generator, save_dir: str) -> None:
 
 
 def test_download_into_custom_directory():
-    global text, lang_code, repo_id, cache_dir, voice
+    global text, lang_code, repo_id, cache_dir, local_dir, voice
 
     pipeline = KPipeline(
         lang_code='a',
         repo_id=repo_id,
-        cache_dir=cache_dir
+        cache_dir=cache_dir,
+        local_dir=local_dir
     )
 
     # Generate and save audio files
@@ -56,7 +57,7 @@ def test_download_into_custom_directory():
 
 
 def test_load_from_local_file() -> None:
-    global text, lang_code, repo_id, cache_dir, voice
+    global text, lang_code, repo_id, cache_dir, local_dir, voice
 
     # use "local_files_only=True" only if: 
     # You are sure that the model is present in the provided cache directory
@@ -64,6 +65,7 @@ def test_load_from_local_file() -> None:
         lang_code='a',
         repo_id=repo_id,
         cache_dir=cache_dir,
+        local_dir=local_dir,
         local_files_only=True
     )
 

--- a/examples/download_custom_dir_example.py
+++ b/examples/download_custom_dir_example.py
@@ -1,0 +1,83 @@
+import os
+import soundfile as sf
+from loguru import logger
+from kokoro import KPipeline
+from typing import Generator
+
+lang_code = 'a'
+repo_id = 'hexgrad/Kokoro-82M'
+cache_dir = os.path.expanduser('~/kokoro_models')
+local_dir = cache_dir
+voice = 'am_michael'
+
+# This text is for demonstration purposes only, unseen during training
+text = '''
+The sky above the port was the color of television, tuned to a dead channel.
+"It's not like I'm using," Case heard someone say, as he shouldered his way through the crowd around the door of the Chat. "It's like my body's developed this massive drug deficiency."
+It was a Sprawl voice and a Sprawl joke. The Chatsubo was a bar for professional expatriates; you could drink there for a week and never hear two words in Japanese.
+
+These were to have an enormous impact, not only because they were associated with Constantine, but also because, as in so many other areas, the decisions taken by Constantine (or in his name) were to have great significance for centuries to come. One of the main issues was the shape that Christian churches were to take, since there was not, apparently, a tradition of monumental church buildings when Constantine decided to help the Christian church build a series of truly spectacular structures. The main form that these churches took was that of the basilica, a multipurpose rectangular structure, based ultimately on the earlier Greek stoa, which could be found in most of the great cities of the empire. Christianity, unlike classical polytheism, needed a large interior space for the celebration of its religious services, and the basilica aptly filled that need. We naturally do not know the degree to which the emperor was involved in the design of new churches, but it is tempting to connect this with the secular basilica that Constantine completed in the Roman forum (the so-called Basilica of Maxentius) and the one he probably built in Trier, in connection with his residence in the city at a time when he was still caesar.
+
+[Kokoro](/kˈOkəɹO/) is an open-weight TTS model with 82 million parameters. Despite its lightweight architecture, it delivers comparable quality to larger models while being significantly faster and more cost-efficient. With Apache-licensed weights, [Kokoro](/kˈOkəɹO/) can be deployed anywhere from production environments to personal projects.
+'''
+
+
+def save_audio(generator: Generator, save_dir: str) -> None:
+    
+    if not os.path.exists(save_dir):
+        os.mkdir(save_dir)
+
+    for i, (gs, ps, audio) in enumerate(generator):
+        print(i)  # i => index
+        print(gs) # gs => graphemes/text
+        print(ps) # ps => phonemes
+
+        # display(Audio(data=audio, rate=24000, autoplay=i==0))
+        save_fp = os.path.join(save_dir, f"kokoro_{i}.wav")
+        sf.write(save_fp, audio, 24000) # save each audio file
+
+
+def test_download_into_custom_directory():
+    global text, lang_code, repo_id, cache_dir, voice
+
+    pipeline = KPipeline(
+        lang_code='a',
+        repo_id=repo_id,
+        cache_dir=cache_dir
+    )
+
+    # Generate and save audio files
+    generator = pipeline(
+        text, voice=voice, # <= change voice here
+        speed=1.1, split_pattern=r'\n+'
+    )
+
+    save_audio(generator, 'download_custom_dir_example')
+
+
+def test_load_from_local_file() -> None:
+    global text, lang_code, repo_id, cache_dir, voice
+
+    # use "local_files_only=True" only if: 
+    # You are sure that the model is present in the provided cache directory
+    pipeline = KPipeline(
+        lang_code='a',
+        repo_id=repo_id,
+        cache_dir=cache_dir,
+        local_files_only=True
+    )
+
+    # Generate and save audio files
+    generator = pipeline(
+        text, voice=voice, # <= change voice here
+        speed=1.1, split_pattern=r'\n+'
+    )
+
+    save_audio(generator, 'load_from_local_file_example')
+
+
+if __name__ == '__main__':
+    logger.info(f'Testing download into custom cache direcotry.\nCustom Cache Directory Set to: {cache_dir}')
+    test_download_into_custom_directory()
+    logger.info(f'Testing loading from custom cache direcotry.\nCustom Cache Directory Set to: {cache_dir}')
+    test_load_from_local_file()

--- a/uv.lock
+++ b/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.10, <3.13"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -428,7 +429,7 @@ wheels = [
 
 [[package]]
 name = "kokoro"
-version = "0.7.16"
+version = "0.8.4"
 source = { editable = "." }
 dependencies = [
     { name = "huggingface-hub" },
@@ -444,7 +445,7 @@ dependencies = [
 requires-dist = [
     { name = "huggingface-hub" },
     { name = "loguru" },
-    { name = "misaki", extras = ["en"], specifier = ">=0.7.16" },
+    { name = "misaki", extras = ["en"], specifier = ">=0.8.4" },
     { name = "numpy", specifier = "==1.26.4" },
     { name = "scipy" },
     { name = "torch" },
@@ -676,14 +677,14 @@ wheels = [
 
 [[package]]
 name = "misaki"
-version = "0.7.16"
+version = "0.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "regex" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6d/ea/704d49d375d475ac1dee144012fc9f4c4a7e408feaa4e15d5999226a147a/misaki-0.7.16.tar.gz", hash = "sha256:ca5a46456391934dc72edc31f20e1db89ddc30897866202cae67152e21bfafa6", size = 3663801 }
+sdist = { url = "https://files.pythonhosted.org/packages/38/35/2e681f15ad20a7440a0772f8351f95beb7b6c15fdc4f6ac60b734f8f62fe/misaki-0.8.4.tar.gz", hash = "sha256:207361518e921c0d4855c595824edbc8e400d593cbd7f5f86d3b74fb70fb91a7", size = 3690597 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/96/979a05fb666983478efc40eb42436e39419e37c26e6d6b0fd4e55cae81db/misaki-0.7.16-py3-none-any.whl", hash = "sha256:a847cbeb69a1082c8c6f2b12ee94fd4e2546db13e534f1e6e0edd2da6892f30d", size = 3517386 },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/06a9c53f96c9d00925cdc4bfc78b2c638802496ee17ecd60e60b8bc39d60/misaki-0.8.4-py3-none-any.whl", hash = "sha256:4baaf45a44ecb13c9d1f56bd7f99d2fb1cf2b0f3b1df0246a103e4e51966c286", size = 3548580 },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
### Summary
Added `cache_dir`, `local_dir` and `local_files_only` parameters to the `KPipeline` and `KModel` classes allowing users to set customized download paths and load local models. Also added an example usage file to: `examples/download_custom_dir_example.py`.

### Example Usage

Set `cache_dir` path, where files downloaded using `hf_hub_download` will be cached.
```python
pipeline = KPipeline(
    lang_code='a',
    cache_dir="/home/user/kokoro_models/cache"
)
```

Users can also specify the local model saving path through `local_dir` parameter to save a local copy of the cached model.
```python
pipeline = KPipeline(
    lang_code='a',
    local_dir="/home/user/kokoro_models/local"
)
```

To use a locally downloaded model, just specify the path in `local_dir` parameter and set `local_files_only` to `True`
```python
pipeline = KPipeline(
    lang_code='a',
    local_dir="/home/user/kokoro_models/local",
    local_files_only=True
)
```

### Why it is useful
The `hf_hub_download` function supports `local_dir`, `cache_dir`, and `local_files_only` parameters allowing users to:

-  Customize storage locations (`local_dir`, `cache_dir`) to manage disk space efficiently.
- Work offline (`local_files_only=True`) by loading pre-downloaded models.
- Reduce redundant downloads, improving performance and cache management.

These features were missing in `kokoro` therefore, has been added to improve flexibility, especially for users handling multiple models or working in restricted environments. 
