### PR TITLE
docs: Add missing setup step in README.md

### DIFF
--- a/kokoro.js/demo/README.md
+++ b/kokoro.js/demo/README.md
@@ -43,7 +43,7 @@ npm run build
 Note this depends on build output from the previous step.
 
 ```sh
-cd kokoro.js/demo
+cd demo
 npm i
 ```
 


### PR DESCRIPTION
The demo depends on the parent directory to be setup

```
    "kokoro-js": "file:..",
```

So added a step.

---

Also the rest of the instructions were very verbose and text was duplicated without adding value. So reworded and trimmed it down.

---

And made the demo localhost link clickable.