### PR TITLE
Enable MPS GPU Accerlation on MacOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ To install espeak-ng on Windows:
 
 For advanced configuration and usage on Windows, see the [official espeak-ng Windows guide](https://github.com/espeak-ng/espeak-ng/blob/master/docs/guide.md)
 
+### MacOS Apple Silicon GPU Acceleration
+
+On Mac M1/M2/M3/M4 devices, you can explicitly specify the environment variable `PYTORCH_ENABLE_MPS_FALLBACK=1` to enable GPU acceleration.
+
+```bash
+PYTORCH_ENABLE_MPS_FALLBACK=1 python run-your-kokoro-script.py
+```
+
 ### Conda Environment
 Use the following conda `environment.yml` if you're facing any dependency issues.
 ```yaml

--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -94,14 +94,14 @@ class KPipeline:
         elif model:
             if device == 'cuda' and not torch.cuda.is_available():
                 raise RuntimeError("CUDA requested but not available")
-            if device is 'mps' and not torch.backends.mps.is_available():
+            if device == 'mps' and not torch.backends.mps.is_available():
                 raise RuntimeError("MPS requested but not available")
-            if device is 'mps' and os.environ.get('PYTORCH_ENABLE_MPS_FALLBACK') != 1:
+            if device == 'mps' and os.environ.get('PYTORCH_ENABLE_MPS_FALLBACK') != '1':
                 raise RuntimeError("MPS requested but fallback not enabled")
             if device is None:
                 if torch.cuda.is_available():
                     device = 'cuda'
-                elif os.environ.get('PYTORCH_ENABLE_MPS_FALLBACK') == 1 and torch.backends.mps.is_available():
+                elif os.environ.get('PYTORCH_ENABLE_MPS_FALLBACK') == '1' and torch.backends.mps.is_available():
                     device = 'mps'
                 else:
                     device = 'cpu'

--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -6,6 +6,7 @@ from misaki import en, espeak
 from typing import Callable, Generator, List, Optional, Tuple, Union
 import re
 import torch
+import os
 
 ALIASES = {
     'en-us': 'a',
@@ -93,8 +94,17 @@ class KPipeline:
         elif model:
             if device == 'cuda' and not torch.cuda.is_available():
                 raise RuntimeError("CUDA requested but not available")
+            if device is 'mps' and not torch.backends.mps.is_available():
+                raise RuntimeError("MPS requested but not available")
+            if device is 'mps' and os.environ.get('PYTORCH_ENABLE_MPS_FALLBACK') != 1:
+                raise RuntimeError("MPS requested but fallback not enabled")
             if device is None:
-                device = 'cuda' if torch.cuda.is_available() else 'cpu'
+                if torch.cuda.is_available():
+                    device = 'cuda'
+                elif os.environ.get('PYTORCH_ENABLE_MPS_FALLBACK') == 1 and torch.backends.mps.is_available():
+                    device = 'mps'
+                else:
+                    device = 'cpu'
             try:
                 self.model = KModel(repo_id=repo_id).to(device).eval()
             except RuntimeError as e:


### PR DESCRIPTION
PyTorch has an **mps** backend as an alternative to **cuda**. 

> [MPS Backend](https://pytorch.org/docs/stable/notes/mps.html): mps device enables high-performance training on GPU for MacOS devices with Metal programming framework. It introduces a new device to map Machine Learning computational graphs and primitives on highly efficient Metal Performance Shaders Graph framework and tuned kernels provided by Metal Performance Shaders framework respectively.

This is the test result on my Mac Mini M4 (the cheapest Mac device):

For small text, the improvement is not significant:
> <img width="904" alt="image" src="https://github.com/user-attachments/assets/7100fce6-4984-40d0-ad17-e6daf275b2b1" />

For longer text, the improvement is a little better:
> <img width="883" alt="image" src="https://github.com/user-attachments/assets/1abf101b-ae64-4139-91a2-be14fb35086b" />

I believe MPS can perform much better than CPU on devices with M4 Pro devices.

