### PR TITLE
Fix a couple minor warnings

### DIFF
--- a/kokoro/istftnet.py
+++ b/kokoro/istftnet.py
@@ -1,6 +1,6 @@
 # ADAPTED from https://github.com/yl4579/StyleTTS2/blob/main/Modules/istftnet.py
 from kokoro.custom_stft import CustomSTFT
-from torch.nn.utils import weight_norm
+from torch.nn.utils.parametrizations import weight_norm
 import math
 import torch
 import torch.nn as nn

--- a/kokoro/modules.py
+++ b/kokoro/modules.py
@@ -1,6 +1,6 @@
 # https://github.com/yl4579/StyleTTS2/blob/main/models.py
 from .istftnet import AdainResBlk1d
-from torch.nn.utils import weight_norm
+from torch.nn.utils.parametrizations import weight_norm
 from transformers import AlbertModel
 import numpy as np
 import torch

--- a/kokoro/modules.py
+++ b/kokoro/modules.py
@@ -139,7 +139,7 @@ class DurationEncoder(nn.Module):
         super().__init__()
         self.lstms = nn.ModuleList()
         for _ in range(nlayers):
-            self.lstms.append(nn.LSTM(d_model + sty_dim, d_model // 2, num_layers=1, batch_first=True, bidirectional=True, dropout=dropout))
+            self.lstms.append(nn.LSTM(d_model + sty_dim, d_model // 2, num_layers=1, batch_first=True, bidirectional=True))
             self.lstms.append(AdaLayerNorm(sty_dim, d_model))
         self.dropout = dropout
         self.d_model = d_model


### PR DESCRIPTION
This fixes a couple minor warnings surfaced by torch:

```
FutureWarning: `torch.nn.utils.weight_norm` is deprecated in favor of `torch.nn.utils.parametrizations.weight_norm`.
```

and

```
UserWarning: dropout option adds dropout after all but last recurrent layer, so non-zero dropout expects num_layers greater than 1, but got dropout=0.2 and num_layers=1
```

Closes #157