### PR TITLE
Set custom cache directory (kokoro-js)

### DIFF
--- a/kokoro.js/src/kokoro.js
+++ b/kokoro.js/src/kokoro.js
@@ -126,9 +126,9 @@ export class KokoroTTS {
       splitter = new TextSplitterStream();
       const chunks = split_pattern
         ? text
-            .split(split_pattern)
-            .map((chunk) => chunk.trim())
-            .filter((chunk) => chunk.length > 0)
+          .split(split_pattern)
+          .map((chunk) => chunk.trim())
+          .filter((chunk) => chunk.length > 0)
         : [text];
       splitter.push(...chunks);
     } else {
@@ -150,6 +150,12 @@ export class KokoroTTS {
 }
 
 export const env = {
+  set cacheDir(value) {
+    hf.cacheDir = value
+  },
+  get cacheDir() {
+    return hf.cacheDir
+  },
   set wasmPaths(value) {
     hf.backends.onnx.wasm.wasmPaths = value;
   },


### PR DESCRIPTION
This fixes an issue, when running `kokoro-js` inside a packaged electron app.

Was getting the following error:
```shell
Error: Load model from /tmp/.mount_LLocalwiNqCl/resources/app.asar/node_modules/@huggingface/transformers/.cache/onnx-community/Kokoro-82M-v1.0-ONNX/onnx/model_q4.onnx fail
ed:system error number 20
    at new OnnxruntimeSessionHandler (/tmp/.mount_LLocalwiNqCl/resources/app.asar/node_modules/onnxruntime-node/dist/backend.js:25:92)
    at Immediate.<anonymous> (/tmp/.mount_LLocalwiNqCl/resources/app.asar/node_modules/onnxruntime-node/dist/backend.js:67:29)
    at process.processImmediate (node:internal/timers:476:21)

Node.js v18.18.2
Error occurred in handler for 'textToSpeech': Error: Stopped the Worker Thread with the exit code: 7
    at ChildProcess.<anonymous> (/tmp/.mount_LLocalwiNqCl/resources/app.asar/out/main/index.js:14221:18)
    at ChildProcess.emit (node:events:517:28)
    at ChildProcess._handle.onexit (node:internal/child_process:292:
    
 ```
 
 This PR adds setter and getter methods for updating and retrieving the cache 
 Updating the cache directory to point outside of the packaged app fixed this 
 Quick sample on how to 
 ```typescript
    import os from "os"
    import { env } from "kokoro-js"
    env.cacheDir = path.join(os.homedir(), '.hfCache') 
```