### PR TITLE
feat: Polyfill async iterator on ReadableStream for Safari

### DIFF
--- a/kokoro.js/demo/package-lock.json
+++ b/kokoro.js/demo/package-lock.json
@@ -8,6 +8,7 @@
       "name": "kokoro-web",
       "version": "0.0.0",
       "dependencies": {
+        "@sec-ant/readable-stream": "^0.6.0",
         "kokoro-js": "file:..",
         "motion": "^11.12.0",
         "react": "^18.3.1",
@@ -1343,6 +1344,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@sec-ant/readable-stream": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.6.0.tgz",
+      "integrity": "sha512-uiBh8DrB5FN35gP6/o8JEhEQ7/ci1jUsOZO/VMUjyvTpjtV54VstOXVj1TvTj/wsT23pfX6butxxh3qufsW3+g==",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",

--- a/kokoro.js/demo/package.json
+++ b/kokoro.js/demo/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@sec-ant/readable-stream": "^0.6.0",
     "kokoro-js": "file:..",
     "motion": "^11.12.0",
     "react": "^18.3.1",

--- a/kokoro.js/demo/src/worker.js
+++ b/kokoro.js/demo/src/worker.js
@@ -1,3 +1,4 @@
+import "@sec-ant/readable-stream/polyfill/asyncIterator";
 import { KokoroTTS } from "kokoro-js";
 import { detectWebGPU } from "./utils.js";
 

--- a/kokoro.js/src/voices.js
+++ b/kokoro.js/src/voices.js
@@ -461,7 +461,7 @@ async function getVoiceFile(id) {
     return buffer;
   }
 
-  const url = `${VOICE_DATA_URL}/${id}.bin`;
+  const url = `${voiceDataUrl}/${id}.bin`;
 
   let cache;
   try {


### PR DESCRIPTION
The kokoro-js demo does not seem to work in Safari because of Safari's lack of support for asyncIterators on ReadableStreams in workers. For the purpose of a demo, polyfilling here seemed like a reasonable course of action.