### PR TITLE
Enable Python 3.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent"
 ]
-requires-python = ">=3.10, <3.13"
+requires-python = ">=3.10, <3.14"
 dependencies = [
     "huggingface_hub",
     "loguru",


### PR DESCRIPTION
Tested working with `kokoro -t Hello -o test.wav`. This is needed for Ubuntu 25.04.

Peer dependency (only needed if using Python 3.13): https://github.com/hexgrad/misaki/pull/85