### PR TITLE
Update dropdown to display CPU as initial option

### DIFF
--- a/demo/app.py
+++ b/demo/app.py
@@ -156,7 +156,7 @@ with gr.Blocks() as app:
             with gr.Row():
                 voice = gr.Dropdown(list(CHOICES.items()), value='af_heart', label='Voice', info='Quality and availability vary by language')
                 use_gpu = gr.Dropdown(
-                    [('ZeroGPU 🚀', True), ('CPU 🐌', False)],
+                    [('CPU 🐌', False), ('ZeroGPU 🚀', True)],
                     value=CUDA_AVAILABLE,
                     label='Hardware',
                     info='GPU is usually faster, but has a usage quota',


### PR DESCRIPTION
<img width="636" height="260" alt="unselectable ZeroGPU when CUDA is not available" src="https://github.com/user-attachments/assets/da51602e-0933-40a5-898c-d43347b98e9d" />

**Issue**
When there is no GPU available, the Hardware dropdown still shows ZeroGPU as the selected option.

**Solution**
According to the [Gradio docs](https://www.gradio.app/docs/gradio/dropdown), the first value in the list is shown. This PR puts the CPU as the first value so that if `CUDA_AVAILABLE` is `False`, it will. show the CPU as the selected option.
