### PR TITLE
japanese: use pyopenjtalk instead of fugashi

### DIFF
--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -124,7 +124,7 @@ class KPipeline:
         elif lang_code == 'j':
             try:
                 from misaki import ja
-                self.g2p = ja.JAG2P()
+                self.g2p = ja.JAG2P(version='pyopenjtalk')
             except ImportError:
                 logger.error("You need to `pip install misaki[ja]` to use lang_code='j'")
                 raise


### PR DESCRIPTION
I had trouble using kokoro because fugashi could not find its unidic dictionary. While looking at misaki and fugashi implementations, I discovered misaki exposed a new tokenizer https://github.com/hexgrad/misaki?tab=readme-ov-file#japanese . Using pyopenjtalk worked out of the box (as the readme mentions, the fugashi approach looks more brittle with several wrappers involved). Apparently it enables accents as well. Having never used the previous one, I cant compare the two but I've used the pyopenjtalk with sucess.