### PR TITLE
AlbertModel import path updation for transformers:latest 

### DIFF
--- a/kokoro/modules.py
+++ b/kokoro/modules.py
@@ -1,7 +1,7 @@
 # https://github.com/yl4579/StyleTTS2/blob/main/models.py
 from .istftnet import AdainResBlk1d
 from torch.nn.utils.parametrizations import weight_norm
-from transformers import AlbertModel
+from transformers.models.albert.modeling_albert import AlbertModel
 import numpy as np
 import torch
 import torch.nn as nn


### PR DESCRIPTION
Change Type: Cosmetic/Minor

Details:
The existing imports for AlbertModel in the .modules results in an error given that the AlbertModel doesn't exist directly in transformers base class exports. Instead explicitly importing it from models helps fix this issue.

✅ FIX 👇
```python
from transformers.models.albert.modeling_albert import AlbertModel
```