### PR TITLE
Add Opire funding link for German language support

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -12,4 +12,4 @@ lfx_crowdfunding: # Replace with a single LFX Crowdfunding project-name e.g., cl
 polar: # Replace with a single Polar username
 buy_me_a_coffee: # Replace with a single Buy Me a Coffee username
 thanks_dev: # Replace with a single thanks.dev username
-custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+custom: ['https://app.opire.dev/issues/01KCKZCP14P37WZQZQA9W6BGJJ']


### PR DESCRIPTION
Fixes #290

Adds the Opire funding link for German language support to .github/FUNDING.yml.

This is a minimal change with no side effects.