### PR TITLE
feat: add German (de) language support

### DIFF
--- a/kokoro.js/src/voices.js
+++ b/kokoro.js/src/voices.js
@@ -312,6 +312,22 @@ export const VOICES = Object.freeze({
   //   targetQuality: "C",
   //   overallGrade: "D",
   // },
+  // df_anna: {
+  //   name: "anna",
+  //   language: "de",
+  //   gender: "Female",
+  //   traits: "🚺",
+  //   targetQuality: "C",
+  //   overallGrade: "D",
+  // },
+  // dm_daniel: {
+  //   name: "daniel",
+  //   language: "de",
+  //   gender: "Male",
+  //   traits: "🚹",
+  //   targetQuality: "C",
+  //   overallGrade: "D",
+  // },
   // ef_dora: {
   //   name: "dora",
   //   language: "es",

--- a/kokoro/__main__.py
+++ b/kokoro/__main__.py
@@ -23,6 +23,7 @@ from loguru import logger
 languages = [
     "a",  # American English
     "b",  # British English
+    "d",  # German
     "h",  # Hindi
     "e",  # Spanish
     "f",  # French

--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -11,6 +11,7 @@ import os
 ALIASES = {
     'en-us': 'a',
     'en-gb': 'b',
+    'de': 'd',
     'es': 'e',
     'fr-fr': 'f',
     'hi': 'h',
@@ -26,6 +27,7 @@ LANG_CODES = dict(
     b='British English',
 
     # espeak-ng
+    d='de',
     e='es',
     f='fr-fr',
     h='hi',

--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -140,6 +140,13 @@ class KPipeline:
             except ImportError:
                 logger.error("You need to `pip install misaki[zh]` to use lang_code='z'")
                 raise
+        elif lang_code == 'd':
+            try:
+                from misaki import de
+                self.g2p = de.DEG2P()
+            except ImportError:
+                logger.error("You need to `pip install misaki[de]` to use lang_code='d'")
+                raise
         else:
             language = LANG_CODES[lang_code]
             logger.warning(f"Using EspeakG2P(language='{language}'). Chunking logic not yet implemented, so long texts may be truncated unless you split them with '\\n'.")


### PR DESCRIPTION
## Summary

Register German as a supported language in Kokoro's pipeline, CLI, and kokoro.js voice list.

### Changes

- Add `'de': 'd'` to `ALIASES` and `d='de'` to `LANG_CODES` in `pipeline.py`
- Add a dedicated `elif lang_code == 'd':` branch that uses `misaki.de.DEG2P()` instead of the generic espeak fallback
- Add `"d"` (German) to the CLI language choices in `__main__.py`
- Add commented-out German voice stubs (`df_anna`, `dm_daniel`) to `kokoro.js/src/voices.js`

German follows the same dedicated-G2P pattern as Japanese (`JAG2P`) and Chinese (`ZHG2P`).

See also:
- `misaki` PR for German G2P: https://github.com/hexgrad/misaki/pull/97
- Related bugfix PR: #318

## Usage

This PR enables `lang_code='d'` / `lang_code='de'` in upstream Kokoro's pipeline and CLI.

```python
pipeline = KPipeline(lang_code='d', repo_id='...')
# or equivalently:
pipeline = KPipeline(lang_code='de', repo_id='...')
```

German synthesis depends on a compatible German-trained model family and matching voice assets.

## Context: Training Recipe and German Model Work

This PR comes out of [kokoro-deutsch](https://github.com/semidark/kokoro-deutsch), a community project that reverse-engineered a working Kokoro fine-tuning pipeline using a patched StyleTTS2. The repo contains:

- End-to-end training recipe (dataset prep -> Stage 1 -> Stage 2 -> voicepack extraction)
- Patched StyleTTS2 submodule with critical fixes for stable Stage 2 training
- A forked `misaki` with German text normalization (`misaki.de.DEG2P`)
- Full documentation (training guide, troubleshooting, architecture notes)

A German multi-speaker base model has been published by the community:

- Model: [dida-80b/kokoro-deutsch-hui-base](https://huggingface.co/dida-80b/kokoro-deutsch-hui-base)
- Dataset: [dida-80b/hui-german-51speakers](https://huggingface.co/datasets/dida-80b/hui-german-51speakers)
- [Intermediate inference sample](https://huggingface.co/datasets/junkstage/kokoro_training/blob/main/bernd_stage1_epoch58.wav)

Important technical note: German voicepacks extracted from this work are tied to the German-trained model family, not to upstream `hexgrad/Kokoro-82M`. Because of that, this PR is intentionally limited to upstream language enablement, while the trained German model assets currently live in the external community project.

## Timeline

- **April 10**: Published [kokoro-deutsch](https://github.com/semidark/kokoro-deutsch)
- **April 10-14**: Fixed critical Stage 2 bugs
- **April 11**: Community contributors began training runs
- **April 14**: Published the initial fork commit adding German language code support
- **April 17**: Added dedicated German text normalization via `misaki.de.DEG2P` and opened upstream `misaki` PR #97

Relates to #290