### PR TITLE
fix: remove stale chunking warning for espeak languages

### DIFF
--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -140,7 +140,6 @@ class KPipeline:
                 raise
         else:
             language = LANG_CODES[lang_code]
-            logger.warning(f"Using EspeakG2P(language='{language}'). Chunking logic not yet implemented, so long texts may be truncated unless you split them with '\\n'.")
             self.g2p = espeak.EspeakG2P(language=language)
 
     def load_single_voice(self, voice: str):


### PR DESCRIPTION
The warning in `KPipeline.__init__` says "Chunking logic not yet implemented, so long texts may be truncated unless you split them with '\\n'." for all espeak-ng languages.

This was accurate when added in Jan 2025, but sentence-level chunking for non-English languages was implemented in #105 (Feb 2025). The warning was never removed and is now misleading.

One line removed, no behavioral change.