### PR TITLE
Add experimental German (lang_code=d) scaffolding for community voices

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ import torch
 # 🇮🇹 'i' => Italian it
 # 🇯🇵 'j' => Japanese: pip install misaki[ja]
 # 🇧🇷 'p' => Brazilian Portuguese pt-br
+# 🇩🇪 'd' => German de (community voices; see docs/german.md)
 # 🇨🇳 'z' => Mandarin Chinese: pip install misaki[zh]
 pipeline = KPipeline(lang_code='a') # <= make sure lang_code matches voice, reference above.
 

--- a/docs/german.md
+++ b/docs/german.md
@@ -1,0 +1,40 @@
+# German (community voices)
+
+Official Kokoro-82M weights are English-first. This guide documents **experimental German support** via:
+
+- `lang_code='d'` — German espeak-ng G2P
+- Optional `kokoro.de_text.normalize_german()` for numbers, EUR, and abbreviations
+- Community-trained `.pt` voice packs (not bundled in `hexgrad/Kokoro-82M`)
+
+## Quick start
+
+```python
+from kokoro import KPipeline
+import soundfile as sf
+import torch
+
+# 1) Download a community German voice .pt (example repos on Hugging Face)
+voice_pt = "path/to/german_voice.pt"  # e.g. community Kokoro-German checkpoints
+
+pipeline = KPipeline(lang_code="d", model=True)
+pack = pipeline.load_voice(voice_pt)
+
+text = "Guten Tag! Das ist ein Test mit 2,5 kWh und 49,99 EUR."
+for i, (_, ps, audio) in enumerate(pipeline(text, voice=voice_pt, speed=1)):
+    if audio is not None:
+        sf.write(f"german_{i}.wav", audio.numpy(), 24000)
+```
+
+## Voices
+
+Community models (quality varies):
+
+- [Tundragoon/Kokoro-German](https://huggingface.co/Tundragoon/Kokoro-German)
+- [huggingFresse/Kokoro-82M-ONNX-German-Martin](https://huggingface.co/huggingFresse/Kokoro-82M-ONNX-German-Martin)
+
+Funding toward **official** German training data is tracked in [GitHub issue #290](https://github.com/hexgrad/kokoro/issues/290).
+
+## Requirements
+
+- `espeak-ng` installed on the system
+- `pip install kokoro` (this package)

--- a/examples/german_tts.py
+++ b/examples/german_tts.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""German TTS demo using lang_code='d' and a community .pt voice file.
+
+Usage:
+  python examples/german_tts.py --voice path/to/voice.pt --text "Guten Tag!"
+"""
+
+import argparse
+import soundfile as sf
+from kokoro import KPipeline
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--voice", required=True, help="Path to German voice .pt pack")
+    p.add_argument("--text", default="Guten Tag! Dies ist ein kurzer Test.")
+    p.add_argument("--out", default="german_out.wav")
+    args = p.parse_args()
+
+    pipeline = KPipeline(lang_code="d")
+    for i, (_, _, audio) in enumerate(pipeline(args.text, voice=args.voice)):
+        if audio is not None:
+            sf.write(args.out, audio.numpy(), 24000)
+            print(f"Wrote {args.out}")
+            return
+    raise SystemExit("No audio generated — check espeak-ng and voice .pt path")
+
+
+if __name__ == "__main__":
+    main()

--- a/kokoro/de_text.py
+++ b/kokoro/de_text.py
@@ -1,0 +1,65 @@
+"""German text normalization helpers for Kokoro espeak G2P (lang_code='d')."""
+
+from __future__ import annotations
+
+import re
+
+# Common German abbreviations expanded before phonemization.
+_ABBREV = {
+    "z.b.": "zum Beispiel",
+    "zzgl.": "zuzüglich",
+    "ca.": "circa",
+    "usw.": "und so weiter",
+    "bzw.": "beziehungsweise",
+    "stck.": "Stück",
+    "min.": "Minuten",
+    "max.": "maximal",
+    "ltr.": "Liter",
+    "mah": "Milliamperestunden",
+    "ma": "Milliampere",
+    "kwh": "Kilowattstunden",
+    "kw": "Kilowatt",
+}
+
+_EUR_RE = re.compile(
+    r"(\d{1,3}(?:\.\d{3})*|\d+),(\d{2})\s*(?:€|eur|euro)\b",
+    re.IGNORECASE,
+)
+_DECIMAL_UNIT_RE = re.compile(
+    r"(\d+),(\d+)\s*(" + "|".join(re.escape(u) for u in ("kwh", "kw", "mah", "ma", "g", "kg", "mb", "gb")) + r")\b",
+    re.IGNORECASE,
+)
+
+
+def normalize_german(text: str) -> str:
+    """Normalize German numerals and abbreviations for more stable TTS."""
+    if not text:
+        return text
+
+    out = text
+    for src, dst in _ABBREV.items():
+        out = re.sub(rf"\b{re.escape(src)}", dst, out, flags=re.IGNORECASE)
+
+    def _eur_sub(m: re.Match[str]) -> str:
+        whole = m.group(1).replace(".", "")
+        cents = m.group(2)
+        return f"{whole} Euro {cents}"
+
+    out = _EUR_RE.sub(_eur_sub, out)
+
+    def _dec_unit_sub(m: re.Match[str]) -> str:
+        whole, frac, unit = m.group(1), m.group(2), m.group(3)
+        unit_word = {
+            "kwh": "Kilowattstunden",
+            "kw": "Kilowatt",
+            "mah": "Milliamperestunden",
+            "ma": "Milliampere",
+            "g": "Gramm",
+            "kg": "Kilogramm",
+            "mb": "Megabyte",
+            "gb": "Gigabyte",
+        }.get(unit.lower(), unit)
+        return f"{whole} Komma {frac} {unit_word}"
+
+    out = _DECIMAL_UNIT_RE.sub(_dec_unit_sub, out)
+    return out

--- a/kokoro/de_text.py
+++ b/kokoro/de_text.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 
-# Common German abbreviations expanded before phonemization.
+# Text abbreviations only (units handled via _DECIMAL_UNIT_RE below).
 _ABBREV = {
     "z.b.": "zum Beispiel",
     "zzgl.": "zuzüglich",
@@ -15,20 +15,38 @@ _ABBREV = {
     "min.": "Minuten",
     "max.": "maximal",
     "ltr.": "Liter",
-    "mah": "Milliamperestunden",
-    "ma": "Milliampere",
+}
+
+_UNIT_WORDS = {
     "kwh": "Kilowattstunden",
     "kw": "Kilowatt",
+    "mah": "Milliamperestunden",
+    "ma": "Milliampere",
+    "g": "Gramm",
+    "kg": "Kilogramm",
+    "mb": "Megabyte",
+    "gb": "Gigabyte",
 }
 
 _EUR_RE = re.compile(
-    r"(\d{1,3}(?:\.\d{3})*|\d+),(\d{2})\s*(?:€|eur|euro)\b",
+    r"(?<!\w)(\d{1,3}(?:\.\d{3})*|\d+),(\d{2})\s*(?:€|eur|euro)(?!\w)",
     re.IGNORECASE,
 )
 _DECIMAL_UNIT_RE = re.compile(
-    r"(\d+),(\d+)\s*(" + "|".join(re.escape(u) for u in ("kwh", "kw", "mah", "ma", "g", "kg", "mb", "gb")) + r")\b",
+    r"(?<!\w)(\d+),(\d+)\s*("
+    + "|".join(re.escape(u) for u in _UNIT_WORDS)
+    + r")(?!\w)",
     re.IGNORECASE,
 )
+
+
+def _apply_abbrevs(text: str) -> str:
+    out = text
+    for src in sorted(_ABBREV, key=len, reverse=True):
+        dst = _ABBREV[src]
+        pattern = rf"(?<!\w){re.escape(src)}(?!\w)"
+        out = re.sub(pattern, dst, out, flags=re.IGNORECASE)
+    return out
 
 
 def normalize_german(text: str) -> str:
@@ -37,8 +55,13 @@ def normalize_german(text: str) -> str:
         return text
 
     out = text
-    for src, dst in _ABBREV.items():
-        out = re.sub(rf"\b{re.escape(src)}", dst, out, flags=re.IGNORECASE)
+
+    def _dec_unit_sub(m: re.Match[str]) -> str:
+        whole, frac, unit = m.group(1), m.group(2), m.group(3)
+        unit_word = _UNIT_WORDS.get(unit.lower(), unit)
+        return f"{whole} Komma {frac} {unit_word}"
+
+    out = _DECIMAL_UNIT_RE.sub(_dec_unit_sub, out)
 
     def _eur_sub(m: re.Match[str]) -> str:
         whole = m.group(1).replace(".", "")
@@ -46,20 +69,5 @@ def normalize_german(text: str) -> str:
         return f"{whole} Euro {cents}"
 
     out = _EUR_RE.sub(_eur_sub, out)
-
-    def _dec_unit_sub(m: re.Match[str]) -> str:
-        whole, frac, unit = m.group(1), m.group(2), m.group(3)
-        unit_word = {
-            "kwh": "Kilowattstunden",
-            "kw": "Kilowatt",
-            "mah": "Milliamperestunden",
-            "ma": "Milliampere",
-            "g": "Gramm",
-            "kg": "Kilogramm",
-            "mb": "Megabyte",
-            "gb": "Gigabyte",
-        }.get(unit.lower(), unit)
-        return f"{whole} Komma {frac} {unit_word}"
-
-    out = _DECIMAL_UNIT_RE.sub(_dec_unit_sub, out)
+    out = _apply_abbrevs(out)
     return out

--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -11,6 +11,9 @@ import os
 ALIASES = {
     'en-us': 'a',
     'en-gb': 'b',
+    'de': 'd',
+    'de-de': 'd',
+    'german': 'd',
     'es': 'e',
     'fr-fr': 'f',
     'hi': 'h',
@@ -37,6 +40,9 @@ LANG_CODES = dict(
 
     # pip install misaki[zh]
     z='Mandarin Chinese',
+
+    # espeak-ng (community German voices: load external .pt packs, see docs/german.md)
+    d='de',
 )
 
 class KPipeline:
@@ -379,6 +385,10 @@ class KPipeline:
         for graphemes_index, graphemes in enumerate(text):
             if not graphemes.strip():  # Skip empty segments
                 continue
+
+            if self.lang_code == 'd':
+                from .de_text import normalize_german
+                graphemes = normalize_german(graphemes)
                 
             # English processing (unchanged)
             if self.lang_code in 'ab':

--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -1,3 +1,4 @@
+from .de_text import normalize_german
 from .model import KModel
 from dataclasses import dataclass
 from huggingface_hub import hf_hub_download
@@ -387,7 +388,6 @@ class KPipeline:
                 continue
 
             if self.lang_code == 'd':
-                from .de_text import normalize_german
                 graphemes = normalize_german(graphemes)
                 
             # English processing (unchanged)

--- a/tests/test_de_text.py
+++ b/tests/test_de_text.py
@@ -1,0 +1,21 @@
+import unittest
+
+from kokoro.de_text import normalize_german
+
+
+class TestGermanNormalization(unittest.TestCase):
+    def test_euro_amount(self):
+        self.assertIn("Euro", normalize_german("Das kostet 49,99 EUR heute."))
+
+    def test_decimal_unit(self):
+        out = normalize_german("Verbrauch: 2,5 kWh pro Tag.")
+        self.assertIn("Komma", out)
+        self.assertIn("Kilowattstunden", out)
+
+    def test_abbreviation(self):
+        out = normalize_german("zzgl. Versand, ca. 3 Tage.")
+        self.assertIn("zuzüglich", out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_de_text.py
+++ b/tests/test_de_text.py
@@ -16,6 +16,11 @@ class TestGermanNormalization(unittest.TestCase):
         out = normalize_german("zzgl. Versand, ca. 3 Tage.")
         self.assertIn("zuzüglich", out)
 
+    def test_max_abbrev_does_not_corrupt_maximal(self):
+        out = normalize_german("max. 10 min.")
+        self.assertIn("maximal", out)
+        self.assertNotIn("Milliampere", out)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Addresses community demand in #290 by adding **first-class German pipeline support** without claiming to ship official trained German weights:

- `lang_code='d'` with espeak-ng German G2P (`de`)
- `kokoro.de_text.normalize_german()` for EUR amounts, decimal units (kWh, etc.), and common abbreviations
- `docs/german.md` — how to use community `.pt` voice packs (Hugging Face)
- `examples/german_tts.py` demo
- Unit tests for normalization

This does **not** replace custom training data for an official hexgrad German release; it unblocks integrators using community checkpoints (e.g. Tundragoon/Kokoro-German, ONNX German voices) with consistent normalization and docs.

## Test plan

- [x] `normalize_german` unit cases (EUR, kWh, zzgl.)
- [ ] Manual: `KPipeline(lang_code='d')` + community `.pt` on a machine with `espeak-ng`

Closes #290 only in the sense of **integration scaffolding**; funding/training remains separate.