### PR TITLE
feat: add German language support for TTS

### DIFF
--- a/kokoro.js/src/phonemize.js
+++ b/kokoro.js/src/phonemize.js
@@ -167,7 +167,7 @@ const PUNCTUATION_PATTERN = new RegExp(`(\\s*[${escapeRegExp(PUNCTUATION)}]+\\s*
 /**
  * Phonemize text using the eSpeak-NG phonemizer
  * @param {string} text The text to phonemize
- * @param {"a"|"b"} language The language to use
+ * @param {"a"|"b"|"d"} language The language to use
  * @param {boolean} norm Whether to normalize the text
  * @returns {Promise<string>} The phonemized text
  */
@@ -181,7 +181,14 @@ export async function phonemize(text, language = "a", norm = true) {
   const sections = split(text, PUNCTUATION_PATTERN);
 
   // 3. Convert each section to phonemes
-  const lang = language === "a" ? "en-us" : "en";
+  let lang;
+  if (language === "a") {
+    lang = "en-us";
+  } else if (language === "d") {
+    lang = "de";
+  } else {
+    lang = "en";
+  }
   const ps = (await Promise.all(sections.map(async ({ match, text }) => (match ? text : (await espeakng(text, lang)).join(" "))))).join("");
 
   // 4. Post-process phonemes

--- a/kokoro/__main__.py
+++ b/kokoro/__main__.py
@@ -23,6 +23,7 @@ from loguru import logger
 languages = [
     "a",  # American English
     "b",  # British English
+    "d",  # German
     "h",  # Hindi
     "e",  # Spanish
     "f",  # French

--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -11,6 +11,7 @@ import os
 ALIASES = {
     'en-us': 'a',
     'en-gb': 'b',
+    'de': 'd',
     'es': 'e',
     'fr-fr': 'f',
     'hi': 'h',
@@ -26,6 +27,7 @@ LANG_CODES = dict(
     b='British English',
 
     # espeak-ng
+    d='de',
     e='es',
     f='fr-fr',
     h='hi',


### PR DESCRIPTION
Adds German language support with lang code 'd', mapped to espeak-ng's 'de' for phonemization. Includes support in both the Python pipeline and JS phonemizer.