### PR TITLE
Loosen misaki[en] pin so pip install kokoro resolves (fixes #321)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">=3.10, <3.14"
 dependencies = [
     "huggingface_hub",
     "loguru",
-    "misaki[en]>=0.9.4",
+    "misaki[en]>=0.9.2",
     "numpy",
     "torch",
     "transformers"


### PR DESCRIPTION
## Problem

`pip install kokoro` can fail with:

```
ERROR: Could not find a version that satisfies the requirement misaki>=0.9.x
ERROR: No matching distribution found for misaki>=0.9.x
```

`kokoro` bumps the `misaki[en]` floor to **its own version number** on every release (currently `misaki[en]>=0.9.4`). Because `kokoro` and `misaki` are published separately, any window where `kokoro` lands on PyPI before the matching `misaki` makes the package un-installable from PyPI alone — even into a fresh venv. This is exactly the failure in #321 (it hit `0.7.16` → `misaki 0.7.4`; the same trap recurs every release).

## Fix

Relax the pin from `misaki[en]>=0.9.4` to `misaki[en]>=0.9.2` — a one-line change.

Why this is safe:

- **The API floor is far below the pin.** kokoro only uses `en.G2P`, `espeak.EspeakFallback/EspeakG2P`, `ja.JAG2P`, and `zh.ZHG2P(version=..., en_callable=...)`. That surface was last matched to **misaki 0.8.0** (commit `efa91a8`, "Match misaki==0.8.0 dev branch") and hasn't changed since — so the exact-version lockstep is unnecessary.
- **No quality regression.** pip/uv still selects the newest available misaki (resolves to `0.9.4` today); `0.9.2` only acts as a fallback during the publish gap, and stays within the `0.9` minor for phoneme/data parity.
- **Consistent with the lockfile.** `uv.lock` already pins `misaki` at `0.9.2` with `specifier = ">=0.9.2"`, so this aligns `pyproject.toml` with what the repo already resolves.

## Reproduction (from the issue)

```bash
python3 -m venv /tmp/test
/tmp/test/bin/pip install kokoro   # failed when misaki lagged kokoro
```

Fixes #321
