### PR TITLE
Add German language support via espeak-ng (lang_code 'de') — addresses #290

### DIFF
--- a/kokoro/__main__.py
+++ b/kokoro/__main__.py
@@ -23,6 +23,7 @@ from loguru import logger
 languages = [
     "a",  # American English
     "b",  # British English
+    "d",  # German
     "h",  # Hindi
     "e",  # Spanish
     "f",  # French

--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -11,6 +11,7 @@ import os
 ALIASES = {
     'en-us': 'a',
     'en-gb': 'b',
+    'de': 'd',
     'es': 'e',
     'fr-fr': 'f',
     'hi': 'h',
@@ -26,6 +27,7 @@ LANG_CODES = dict(
     b='British English',
 
     # espeak-ng
+    d='de',
     e='es',
     f='fr-fr',
     h='hi',


### PR DESCRIPTION
## German language support via espeak-ng (`lang_code='de'` / `'d'`)

Closes the practical gap behind #290: Kokoro had **no German entry in its language table**, even though it already drives Spanish, French, Italian, Portuguese and Hindi through `espeak.EspeakG2P`, and `espeak-ng` ships German out of the box. German just needed to join that family.

This is the pragmatic path @kneo described in #290 — *"provided the correct phonemes, existing models may just work"*: `espeak-ng` produces correct German IPA, and the multilingual checkpoint consumes IPA.

### Change (3 lines, no new dependency)

```python
ALIASES   += {'de': 'd'}
LANG_CODES += {'d': 'de'}   # under the espeak-ng group
languages += ['d']          # CLI
```

The existing `else` branch then constructs `EspeakG2P(language='de')` automatically — **no new code branch**. `espeak-ng` is already required (it backs the English G2P fallback and every other espeak language), so there is **nothing new to install**.

### Usage

```python
from kokoro import KPipeline
pipe = KPipeline(lang_code='de')   # 'd' also works
```
```bash
python3 -m kokoro -l d --text "Guten Tag, wie geht es dir?"
```

### Verified

```
"Guten Tag, wie geht es dir? Künstliche Intelligenz ist faszinierend."
→ ɡˈuːtən tˈɑːk, viː ɡˈeːt ɛs dˈiːɾ? kˈynstlɪçə ˌɪntəlɪɡˈɛnʦ ɪst fˌasʦiːnˈiːrənt.
```

### Relationship to #317

#317 routes German to `from misaki import de; de.DEG2P()`, but `misaki[de]` does not exist on PyPI, so that path raises `ImportError` for every user today. This PR uses the **already-working** espeak path instead, so German works immediately.

### Scope (honest)

Same tier and caveats as the other espeak languages: chunking isn't implemented for non-English (split long text on `\n`), and prosody quality varies because the base checkpoint wasn't fine-tuned on German. This is a working out-of-the-box German path **now**, complementary to a future dedicated `misaki[de]` / German fine-tune (the larger goal the #290 bounty funds).

Addresses #290
