### PR TITLE
feat: add German language support via espeak-ng (lang_code='d'/'de')

### DIFF
--- a/kokoro/__main__.py
+++ b/kokoro/__main__.py
@@ -23,6 +23,7 @@ from loguru import logger
 languages = [
     "a",  # American English
     "b",  # British English
+    "d",  # German
     "h",  # Hindi
     "e",  # Spanish
     "f",  # French

--- a/kokoro/pipeline.py
+++ b/kokoro/pipeline.py
@@ -11,6 +11,7 @@ import os
 ALIASES = {
     'en-us': 'a',
     'en-gb': 'b',
+    'de': 'd',
     'es': 'e',
     'fr-fr': 'f',
     'hi': 'h',
@@ -26,6 +27,7 @@ LANG_CODES = dict(
     b='British English',
 
     # espeak-ng
+    d='de',
     e='es',
     f='fr-fr',
     h='hi',
@@ -140,7 +142,7 @@ class KPipeline:
                 raise
         else:
             language = LANG_CODES[lang_code]
-            logger.warning(f"Using EspeakG2P(language='{language}'). Chunking logic not yet implemented, so long texts may be truncated unless you split them with '\\n'.")
+            logger.debug(f"Using EspeakG2P(language='{language}') with sentence-boundary chunking.")
             self.g2p = espeak.EspeakG2P(language=language)
 
     def load_single_voice(self, voice: str):


### PR DESCRIPTION
## Summary

Adds German language support using the existing `EspeakG2P` pipeline, consistent with how Spanish, French, Italian, Hindi, and Portuguese are already supported.

### Changes

- **`kokoro/pipeline.py`**
  - Add `'de': 'd'` alias to `ALIASES`
  - Add `'d': 'de'` entry to `LANG_CODES` (under `# espeak-ng`)
  - Remove outdated warning that claimed "chunking logic not yet implemented" — the `__call__` method already handles sentence-boundary chunking for all non-English languages

- **`kokoro/__main__.py`**
  - Add `'d'` (German) to the CLI `--language` choices

### Usage

```python
from kokoro import KPipeline

pipeline = KPipeline(lang_code='d')  # or lang_code='de'
for result in pipeline('Guten Morgen, wie geht es Ihnen?', voice='df_...'):
    # result.audio is the generated audio
    ...
```

```bash
python3 -m kokoro -l d --voice df_... -t "Guten Morgen" -o output.wav
```

### Notes

- Uses `espeak-ng` G2P, same as all other non-English/non-CJK languages
- Long texts are automatically split on sentence boundaries (`.!?`) via the existing chunking logic in `__call__`
- Requires `espeak-ng` to be installed (`apt-get install espeak-ng`)

Closes #290