### PR TITLE
Add Mandarin support to kokoro-js

### DIFF
--- a/kokoro.js/README.md
+++ b/kokoro.js/README.md
@@ -37,6 +37,14 @@ const audio = await tts.generate(text, {
 audio.save("audio.wav");
 ```
 
+Mandarin Chinese is supported by selecting a `zf_` or `zm_` voice:
+
+```js
+const audio = await tts.generate("每一本书都值得被听见。", {
+  voice: "zf_xiaobei",
+});
+```
+
 Or if you'd prefer to stream the output, you can do that with:
 
 ```js

--- a/kokoro.js/package-lock.json
+++ b/kokoro.js/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@huggingface/transformers": "^3.5.1",
-        "phonemizer": "^1.2.1"
+        "phonemizer": "^1.2.1",
+        "pinyin-pro": "^3.28.2"
       },
       "devDependencies": {
         "@rollup/plugin-node-resolve": "^16.0.0",
@@ -2165,6 +2166,12 @@
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
       }
+    },
+    "node_modules/pinyin-pro": {
+      "version": "3.28.2",
+      "resolved": "https://registry.npmjs.org/pinyin-pro/-/pinyin-pro-3.28.2.tgz",
+      "integrity": "sha512-jV38yxXHLfidirMC4hrXasLDozLCSq/4DfX88GnHcSEJ2+GpSedG6I9VOiEXJu6iQ5dbJC/RjmzyMuS5h/wH5A==",
+      "license": "MIT"
     },
     "node_modules/platform": {
       "version": "1.3.6",

--- a/kokoro.js/package.json
+++ b/kokoro.js/package.json
@@ -35,7 +35,8 @@
   "description": "High-quality text-to-speech for the web",
   "dependencies": {
     "@huggingface/transformers": "^3.5.1",
-    "phonemizer": "^1.2.1"
+    "phonemizer": "^1.2.1",
+    "pinyin-pro": "^3.28.2"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^16.0.0",

--- a/kokoro.js/src/kokoro.js
+++ b/kokoro.js/src/kokoro.js
@@ -60,7 +60,7 @@ export class KokoroTTS {
       console.table(VOICES);
       throw new Error(`Voice "${voice}" not found. Should be one of: ${Object.keys(VOICES).join(", ")}.`);
     }
-    const language = /** @type {"a"|"b"} */ (voice.at(0)); // "a" or "b"
+    const language = /** @type {"a"|"b"|"z"} */ (voice.at(0));
     return language;
   }
 

--- a/kokoro.js/src/phonemize-zh.js
+++ b/kokoro.js/src/phonemize-zh.js
@@ -1,0 +1,105 @@
+import { pinyin } from "pinyin-pro";
+
+const INITIALS = {
+  b: "p", c: "ʦʰ", ch: "ꭧʰ", d: "t", f: "f", g: "k", h: "x",
+  j: "ʨ", k: "kʰ", l: "l", m: "m", n: "n", p: "pʰ", q: "ʨʰ",
+  r: "ɻ", s: "s", sh: "ʂ", t: "tʰ", x: "ɕ", z: "ʦ", zh: "ꭧ",
+};
+
+const FINALS = {
+  a: "a", ai: "ai̯", an: "an", ang: "aŋ", ao: "au̯",
+  e: "ɤ", ei: "ei̯", en: "ən", eng: "əŋ", er: "ɚ",
+  i: "i", ia: "ja", ian: "jɛn", iang: "jaŋ", iao: "jau̯",
+  ie: "je", in: "in", iou: "jou̯", ing: "iŋ", iong: "jʊŋ",
+  o: "wo", ong: "ʊŋ", ou: "ou̯",
+  u: "u", ua: "wa", uai: "wai̯", uan: "wan", uang: "waŋ",
+  uei: "wei̯", uen: "wən", ueng: "wəŋ", uo: "wo",
+  ü: "y", üe: "ɥe", üan: "ɥɛn", ün: "yn",
+};
+
+const TONES = { 1: "→", 2: "↗", 3: "↓", 4: "↘", 5: "" };
+const INITIAL_PATTERN = /^(zh|ch|sh|[bpmfdtnlgkhjqxrzcsyw])/;
+
+function normalizeSyllable(syllable) {
+  const match = syllable.toLowerCase().match(/^([a-züvê]+)([1-5])$/u);
+  if (!match) return null;
+  let [, body, tone] = match;
+  body = body.replaceAll("v", "ü");
+
+  let initial = body.match(INITIAL_PATTERN)?.[0] ?? "";
+  let final = body.slice(initial.length);
+
+  if (initial === "y") {
+    const yFinals = {
+      i: "i", a: "ia", ao: "iao", e: "ie", ou: "iou", an: "ian",
+      in: "in", ang: "iang", ing: "ing", ong: "iong", u: "ü",
+      ue: "üe", uan: "üan", un: "ün",
+    };
+    final = yFinals[final] ?? final;
+    initial = "";
+  } else if (initial === "w") {
+    const wFinals = {
+      u: "u", a: "ua", o: "uo", ai: "uai", ei: "uei",
+      an: "uan", en: "uen", ang: "uang", eng: "ueng",
+    };
+    final = wFinals[final] ?? final;
+    initial = "";
+  } else {
+    if (final === "iu") final = "iou";
+    if (final === "ui") final = "uei";
+    if (final === "un") final = ["j", "q", "x"].includes(initial) ? "ün" : "uen";
+    if (["j", "q", "x"].includes(initial) && final.startsWith("u")) {
+      final = `ü${final.slice(1)}`;
+    }
+  }
+
+  if (final === "i" && ["zh", "ch", "sh", "r"].includes(initial)) final = "ɻ̩";
+  if (final === "i" && ["z", "c", "s"].includes(initial)) final = "ɹ̩";
+
+  const initialIpa = INITIALS[initial] ?? "";
+  const finalIpa = FINALS[final] ?? final;
+  return `${initialIpa}${finalIpa}${TONES[Number(tone)]}`;
+}
+
+function mapPunctuation(text) {
+  return text
+    .replace(/[、，]/g, ", ")
+    .replace(/[。．]/g, ". ")
+    .replace(/！/g, "! ")
+    .replace(/：/g, ": ")
+    .replace(/；/g, "; ")
+    .replace(/？/g, "? ")
+    .replace(/[«《「【]/g, " “")
+    .replace(/[»》」】]/g, "” ")
+    .replace(/（/g, " (")
+    .replace(/）/g, ") ");
+}
+
+/**
+ * Convert Mandarin text to Kokoro-compatible IPA.
+ * @param {string} text
+ * @param {(text: string) => Promise<string>} [englishPhonemize]
+ * @returns {Promise<string>}
+ */
+export async function phonemizeChinese(text, englishPhonemize) {
+  const tokens = pinyin(mapPunctuation(text), {
+    toneType: "num",
+    type: "array",
+    nonZh: "consecutive",
+  });
+
+  const output = [];
+  for (const token of tokens) {
+    const ipa = normalizeSyllable(token);
+    if (ipa) {
+      output.push(ipa);
+    } else if (englishPhonemize && /[A-Za-z]/.test(token)) {
+      output.push(await englishPhonemize(token.trim()));
+    } else {
+      output.push(token);
+    }
+  }
+  return output.join("").replace(/\s+/g, " ").trim();
+}
+
+export { normalizeSyllable };

--- a/kokoro.js/src/phonemize.js
+++ b/kokoro.js/src/phonemize.js
@@ -1,4 +1,5 @@
 import { phonemize as espeakng } from "phonemizer";
+import { phonemizeChinese } from "./phonemize-zh.js";
 
 /**
  * Helper function to split a string on a regex, but keep the delimiters.
@@ -167,11 +168,15 @@ const PUNCTUATION_PATTERN = new RegExp(`(\\s*[${escapeRegExp(PUNCTUATION)}]+\\s*
 /**
  * Phonemize text using the eSpeak-NG phonemizer
  * @param {string} text The text to phonemize
- * @param {"a"|"b"} language The language to use
+ * @param {"a"|"b"|"z"} language The language to use
  * @param {boolean} norm Whether to normalize the text
  * @returns {Promise<string>} The phonemized text
  */
 export async function phonemize(text, language = "a", norm = true) {
+  if (language === "z") {
+    return phonemizeChinese(text, (english) => phonemize(english, "a", true));
+  }
+
   // 1. Normalize text
   if (norm) {
     text = normalize_text(text);

--- a/kokoro.js/src/voices.js
+++ b/kokoro.js/src/voices.js
@@ -206,6 +206,62 @@ export const VOICES = Object.freeze({
     targetQuality: "B",
     overallGrade: "C",
   },
+  zf_xiaobei: {
+    name: "Xiaobei",
+    language: "zh",
+    gender: "Female",
+    targetQuality: "C",
+    overallGrade: "D",
+  },
+  zf_xiaoni: {
+    name: "Xiaoni",
+    language: "zh",
+    gender: "Female",
+    targetQuality: "C",
+    overallGrade: "D",
+  },
+  zf_xiaoxiao: {
+    name: "Xiaoxiao",
+    language: "zh",
+    gender: "Female",
+    targetQuality: "C",
+    overallGrade: "D",
+  },
+  zf_xiaoyi: {
+    name: "Xiaoyi",
+    language: "zh",
+    gender: "Female",
+    targetQuality: "C",
+    overallGrade: "D",
+  },
+  zm_yunjian: {
+    name: "Yunjian",
+    language: "zh",
+    gender: "Male",
+    targetQuality: "C",
+    overallGrade: "D",
+  },
+  zm_yunxi: {
+    name: "Yunxi",
+    language: "zh",
+    gender: "Male",
+    targetQuality: "C",
+    overallGrade: "D",
+  },
+  zm_yunxia: {
+    name: "Yunxia",
+    language: "zh",
+    gender: "Male",
+    targetQuality: "C",
+    overallGrade: "D",
+  },
+  zm_yunyang: {
+    name: "Yunyang",
+    language: "zh",
+    gender: "Male",
+    targetQuality: "C",
+    overallGrade: "D",
+  },
 
   // TODO: Add support for other languages:
   // jf_alpha: {

--- a/kokoro.js/tests/phonemize.test.js
+++ b/kokoro.js/tests/phonemize.test.js
@@ -92,4 +92,17 @@ describe("phonemize", () => {
       });
     }
   });
+  describe("zh", () => {
+    test("phonemizes Mandarin characters and punctuation", async () => {
+      expect(await phonemize("你好，世界！", "z")).toEqual("ni↓xau̯↓, ʂɻ̩↘ʨje↘!");
+    });
+
+    test("keeps mixed English text", async () => {
+      expect(await phonemize("你好 Kokoro", "z")).toContain("kˈoʊkəɹoʊ");
+    });
+
+    test("handles ü finals", async () => {
+      expect(await phonemize("女儿", "z")).toEqual("ny↓ɚ↗");
+    });
+  });
 });


### PR DESCRIPTION
## What changed

- adds a browser-compatible Mandarin grapheme-to-phoneme path for `kokoro-js`
- converts numbered pinyin to the IPA and tone symbols expected by Kokoro
- exposes the eight existing `zf_` and `zm_` Mandarin voice assets
- preserves English fragments in mixed Chinese/English input
- documents Mandarin generation and adds focused phonemization tests

## Why

The repository already ships Mandarin voice data and the Python pipeline supports `lang_code="z"`, but `kokoro-js` validates only American and British English voices. Selecting a Mandarin voice therefore fails before synthesis, and the JavaScript package has no Mandarin phonemizer.

## Impact

Browser and Node users can synthesize Mandarin locally with the existing Kokoro v1.0 ONNX model by selecting a Chinese voice such as `zf_xiaobei`.

## Validation

- `npm test`: 279 tests passed
- `npm run build`: Node and browser bundles built successfully
- end-to-end generation: synthesized `你好，欢迎使用 Kokoro。` with `zf_xiaobei` into 82,200 samples at 24 kHz
